### PR TITLE
webgl2 may not be available in all environments

### DIFF
--- a/src/device/XRDevice.ts
+++ b/src/device/XRDevice.ts
@@ -370,18 +370,20 @@ export class XRDevice {
 	}
 
 	installRuntime(globalObject: any = globalThis) {
-		Object.defineProperty(
-			WebGL2RenderingContext.prototype,
-			'makeXRCompatible',
-			{
-				value: function () {
-					return new Promise((resolve, _reject) => {
-						resolve(true);
-					});
+		if (WebGL2RenderingContext) {
+			Object.defineProperty(
+				WebGL2RenderingContext.prototype,
+				'makeXRCompatible',
+				{
+					value: function () {
+						return new Promise((resolve, _reject) => {
+							resolve(true);
+						});
+					},
+					configurable: true,
 				},
-				configurable: true,
-			},
-		);
+			);
+		}
 		this[PRIVATE].xrSystem = new XRSystem(this);
 		Object.defineProperty(globalThis.navigator, 'xr', {
 			value: this[PRIVATE].xrSystem,


### PR DESCRIPTION
We have regression tests for older browser support.

Some browser may only have webgl.

This patch ensures the code is robust and will not crash on older browsers (and test environments)