### PR TITLE
remove unnecessary @types/gl-matrix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
 				"@rollup/plugin-commonjs": "^25.0.7",
 				"@rollup/plugin-node-resolve": "^15.2.3",
 				"@rollup/plugin-terser": "^0.4.4",
-				"@types/gl-matrix": "^3.2.0",
 				"@types/jest": "^29.5.11",
 				"@types/node": "^18.7.13",
 				"@types/three": "^0.149.0",
@@ -2435,16 +2434,6 @@
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
 			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
 			"dev": true
-		},
-		"node_modules/@types/gl-matrix": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@types/gl-matrix/-/gl-matrix-3.2.0.tgz",
-			"integrity": "sha512-CY4JAtSOGQX7rVgqVuOk7ZfaLv8VeadDMPj3smMOy8Hp/YiHONa3Mr0mEUgbo0eEwV7+Owpf6BwspcA7hv4NXg==",
-			"deprecated": "This is a stub types definition. gl-matrix provides its own type definitions, so you do not need this installed.",
-			"dev": true,
-			"dependencies": {
-				"gl-matrix": "*"
-			}
 		},
 		"node_modules/@types/graceful-fs": {
 			"version": "4.1.9",
@@ -10502,15 +10491,6 @@
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
 			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
 			"dev": true
-		},
-		"@types/gl-matrix": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@types/gl-matrix/-/gl-matrix-3.2.0.tgz",
-			"integrity": "sha512-CY4JAtSOGQX7rVgqVuOk7ZfaLv8VeadDMPj3smMOy8Hp/YiHONa3Mr0mEUgbo0eEwV7+Owpf6BwspcA7hv4NXg==",
-			"dev": true,
-			"requires": {
-				"gl-matrix": "*"
-			}
 		},
 		"@types/graceful-fs": {
 			"version": "4.1.9",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
 		"@rollup/plugin-commonjs": "^25.0.7",
 		"@rollup/plugin-node-resolve": "^15.2.3",
 		"@rollup/plugin-terser": "^0.4.4",
-		"@types/gl-matrix": "^3.2.0",
 		"@types/jest": "^29.5.11",
 		"@types/node": "^18.7.13",
 		"@types/three": "^0.149.0",


### PR DESCRIPTION
gl-matrix has own type definitions, so `@types/gl-matrix` is unnecessary.
I executed `npm uninstall @types/gl-matrix`.