### PR TITLE
Dispatch primary action events in the order expected

### DIFF
--- a/src/device/XRTrackedInput.ts
+++ b/src/device/XRTrackedInput.ts
@@ -96,13 +96,13 @@ export class XRTrackedInput {
 						button[P_GAMEPAD].value > 0
 					) {
 						session.dispatchEvent(
-							new XRInputSourceEvent(button[P_GAMEPAD].eventTrigger, {
+							new XRInputSourceEvent(button[P_GAMEPAD].eventTrigger + 'start', {
 								frame,
 								inputSource: this[P_TRACKED_INPUT].inputSource,
 							}),
 						);
 						session.dispatchEvent(
-							new XRInputSourceEvent(button[P_GAMEPAD].eventTrigger + 'start', {
+							new XRInputSourceEvent(button[P_GAMEPAD].eventTrigger, {
 								frame,
 								inputSource: this[P_TRACKED_INPUT].inputSource,
 							}),

--- a/tests/session/XRSession.test.ts
+++ b/tests/session/XRSession.test.ts
@@ -280,12 +280,11 @@ describe('XRSession', () => {
 	});
 
 	test('Select, selectstart, selectend events are correctly fired', async () => {
-		const mockOnSelect = jest.fn();
-		const mockOnSelectStart = jest.fn();
-		const mockOnSelectEnd = jest.fn();
-		xrSession.addEventListener('select', mockOnSelect);
-		xrSession.addEventListener('selectstart', mockOnSelectStart);
-		xrSession.addEventListener('selectend', mockOnSelectEnd);
+		const callOrder: string[] = [];
+		const mockSelectCallback = jest.fn((event) => callOrder.push(event.type));
+		xrSession.addEventListener('select', mockSelectCallback);
+		xrSession.addEventListener('selectstart', mockSelectCallback);
+		xrSession.addEventListener('selectend', mockSelectCallback);
 		let frameId = 0;
 		const onFrame = (_time: number, _frame: XRFrame) => {
 			frameId++;
@@ -303,18 +302,15 @@ describe('XRSession', () => {
 		};
 		xrSession.requestAnimationFrame(onFrame);
 		jest.runAllTimers();
-		expect(mockOnSelect).toHaveBeenCalled();
-		expect(mockOnSelectStart).toHaveBeenCalled();
-		expect(mockOnSelectEnd).toHaveBeenCalled();
+		expect(callOrder).toEqual(['selectstart', 'select', 'selectend']);
 	});
 
 	test('Squeeze, squeezestart, squeezeend events are correctly fired', async () => {
-		const mockOnSqueeze = jest.fn();
-		const mockOnSqueezeStart = jest.fn();
-		const mockOnSqueezeEnd = jest.fn();
-		xrSession.addEventListener('squeeze', mockOnSqueeze);
-		xrSession.addEventListener('squeezestart', mockOnSqueezeStart);
-		xrSession.addEventListener('squeezeend', mockOnSqueezeEnd);
+		const callOrder: string[] = [];
+		const mockSqueezeCallback = jest.fn((event) => callOrder.push(event.type));
+		xrSession.addEventListener('squeeze', mockSqueezeCallback);
+		xrSession.addEventListener('squeezestart', mockSqueezeCallback);
+		xrSession.addEventListener('squeezeend', mockSqueezeCallback);
 		let frameId = 0;
 		const onFrame = (_time: number, _frame: XRFrame) => {
 			frameId++;
@@ -332,9 +328,8 @@ describe('XRSession', () => {
 		};
 		xrSession.requestAnimationFrame(onFrame);
 		jest.runAllTimers();
-		expect(mockOnSqueeze).toHaveBeenCalled();
-		expect(mockOnSqueezeStart).toHaveBeenCalled();
-		expect(mockOnSqueezeEnd).toHaveBeenCalled();
+		expect(mockSqueezeCallback).toHaveBeenCalled();
+		expect(callOrder).toEqual(['squeezestart', 'squeeze', 'squeezeend']);
 	});
 
 	test('XRSession.environmentBlendMode returns the correct value', async () => {


### PR DESCRIPTION
Change will dispatch primary action events in the order expected in latest recommendation draft.
Tests do validate execution of callbacks and the expected order of execution.
