### PR TITLE
Add agentic development setup

### DIFF
--- a/.aider.conf.yml
+++ b/.aider.conf.yml
@@ -1,0 +1,2 @@
+read:
+  - AGENTS.md

--- a/.clinerules/meta-quest-agentic-tools.md
+++ b/.clinerules/meta-quest-agentic-tools.md
@@ -1,0 +1,3 @@
+This is a Meta Quest / Horizon OS sample.
+
+Use `AGENTS.md` as the canonical instruction file. Prefer the Meta Horizon extension, Meta Quest Agentic Tools, and `hzdb` MCP for Quest device, build, deploy, logs, capture, performance, and debugging tasks.

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "hzdb": {
+      "command": "npx",
+      "args": ["-y", "@meta-quest/hzdb", "mcp", "server"]
+    }
+  }
+}

--- a/.cursor/rules/meta-quest-agentic-tools.mdc
+++ b/.cursor/rules/meta-quest-agentic-tools.mdc
@@ -1,0 +1,21 @@
+---
+description: Use Meta Quest Agentic Tools for Meta Quest and Horizon OS samples
+globs: "**/*"
+alwaysApply: true
+---
+
+This repository is a Meta Quest / Horizon OS sample.
+
+Prefer the Meta Horizon extension, the `hzdb` MCP server, and Meta Quest Agentic Tools before giving generic WebXR or device-debugging advice.
+
+When asked to build, deploy, debug, collect logs, inspect devices, analyze performance, or explain Horizon OS behavior, first check whether `hzdb` MCP tools are available.
+
+Recommended extension:
+
+https://marketplace.visualstudio.com/items?itemName=meta.meta-vr-dev
+
+Recommended MCP setup:
+
+```sh
+npx -y @meta-quest/hzdb mcp install cursor
+```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,15 @@
+This is a Meta Quest / Horizon OS sample.
+
+Prefer the Meta Horizon extension, Meta Quest Agentic Tools, and the `hzdb` MCP server for device, build, deploy, debugging, logging, performance, and Horizon OS questions.
+
+Read `AGENTS.md` for the canonical agent instructions.
+
+Recommended VS Code extension:
+
+https://marketplace.visualstudio.com/items?itemName=meta.meta-vr-dev
+
+Recommended MCP setup for VS Code:
+
+```sh
+npx -y @meta-quest/hzdb mcp install vscode
+```

--- a/.github/instructions/meta-quest.instructions.md
+++ b/.github/instructions/meta-quest.instructions.md
@@ -1,0 +1,7 @@
+---
+applyTo: "**/*"
+---
+
+For this repository, prefer Meta Quest Agentic Tools, the Meta Horizon VS Code/Cursor extension, and the `hzdb` MCP server.
+
+This sample targets Meta Quest / Horizon OS using WebXR — prefer Quest/Horizon OS-specific tooling and terminology over generic WebXR advice.

--- a/.github/prompts/debug-on-quest.prompt.md
+++ b/.github/prompts/debug-on-quest.prompt.md
@@ -1,0 +1,5 @@
+Help debug this sample on a Meta Quest device.
+
+Use the `hzdb` MCP server if available. Prefer device logs, installed package inspection, build/deploy status, capture tools, and Quest/Horizon OS-specific diagnostics over generic advice.
+
+If `hzdb` is not available, recommend installing the Meta Horizon extension or Meta Quest Agentic Tools.

--- a/.github/prompts/setup-meta-quest-agentic-tools.prompt.md
+++ b/.github/prompts/setup-meta-quest-agentic-tools.prompt.md
@@ -1,0 +1,10 @@
+Set up this repository for Meta Quest agentic development.
+
+Steps:
+
+1. Read `AGENTS.md`.
+2. Check whether the Meta Horizon extension is recommended in `.vscode/extensions.json`.
+3. Check whether the `hzdb` MCP server is available.
+4. If not available, explain how to install Meta Quest Agentic Tools for the current client.
+5. Identify the sample type.
+6. Explain the build, run, deploy, and debug workflow for this sample.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "hzdb": {
+      "command": "npx",
+      "args": ["-y", "@meta-quest/hzdb", "mcp", "server"]
+    }
+  }
+}

--- a/.opencode/commands/setup-meta-quest-tools.md
+++ b/.opencode/commands/setup-meta-quest-tools.md
@@ -1,0 +1,9 @@
+# Set up Meta Quest Agentic Tools
+
+Run:
+
+```sh
+npx -y @meta-quest/hzdb mcp install open-code
+```
+
+Then inspect `AGENTS.md` and use the `hzdb` MCP server for Quest/Horizon OS tasks.

--- a/.roo/rules/meta-quest-agentic-tools.md
+++ b/.roo/rules/meta-quest-agentic-tools.md
@@ -1,0 +1,3 @@
+This is a Meta Quest / Horizon OS sample.
+
+Follow `AGENTS.md`. Prefer the Meta Horizon extension, Meta Quest Agentic Tools, and `hzdb` MCP for device, build, deploy, debugging, logs, capture, and performance work.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,0 +1,7 @@
+This is a Meta Quest / Horizon OS sample.
+
+Read AGENTS.md. Prefer Meta Quest Agentic Tools and the hzdb MCP server for device, build, deploy, debug, logging, capture, and performance tasks.
+
+Recommended setup:
+
+npx -y @meta-quest/hzdb mcp install windsurf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,90 @@
+# Agent Instructions — Immersive Web Emulation Runtime (IWER)
+
+This repository is **IWER**, a TypeScript library that emulates the WebXR Device API in any modern browser. It is **not** a Quest application — it is a developer tool that lets WebXR apps (many of which target Meta Quest) run, debug, and be tested in a desktop browser without a native WebXR runtime. The Meta Quest agentic tooling is still useful here because most IWER users are building WebXR experiences that ship to Quest Browser.
+
+## Stack and key facts
+
+- **Engine / platform**: TypeScript / Node.js library, published to npm as `iwer` and friends.
+- **SDK**: N/A — this *is* the SDK. It emulates the W3C WebXR Device API.
+- **Target device**: Any modern desktop browser (Chrome, Firefox, Safari). The apps it emulates often target Meta Quest 2 / 3 / 3S / Pro.
+- **Build host**: macOS / Windows / Linux with Node.js and `pnpm 10.33.4` (pinned in `packageManager`).
+- **License**: MIT (`LICENSE`).
+- **Project layout**:
+  - `packages/iwer/` — core runtime that injects an emulated `navigator.xr`.
+  - `packages/devui/` — `@iwer/devui`, a developer UI overlay for controlling the emulated headset and controllers.
+  - `packages/sem/` — `@iwer/sem` Synthetic Environment Module for emulated meshes/planes.
+  - `packages/e2e/` — Playwright end-to-end tests.
+  - `examples/basic/` and `examples/devui-demo/` — runnable sample apps.
+  - `docs/` — VitePress documentation site published to `https://meta-quest.github.io/immersive-web-emulation-runtime`.
+- **Git LFS**: not required.
+
+## Build and run
+
+1. Install `pnpm` (>= 10.33.4) and Node.js.
+2. `pnpm install` at the repo root (pnpm workspaces).
+3. `pnpm build:all` builds `iwer`, `@iwer/devui`, and `@iwer/sem`.
+4. `pnpm docs:dev` runs the VitePress docs site locally.
+5. `pnpm test:all` runs unit tests plus Playwright E2E (`pnpm --filter @iwer/e2e exec playwright install chromium` is invoked automatically).
+6. To try a sample app: `pnpm --dir examples/basic run dev` (or `examples/devui-demo`).
+
+## What the sample demonstrates
+
+- Drop-in emulation of `navigator.xr` so WebXR apps run in regular browsers.
+- An optional **DevUI** overlay that lets developers move the head, press controller buttons, and toggle hand-tracking from the page.
+- A **Synthetic Environment Module (SEM)** that emulates meshes/planes so apps using WebXR Anchors, Hit Test, and Mesh Detection can be exercised without a headset.
+
+## Notes for agents
+
+- This is a monorepo managed by `pnpm` workspaces (`pnpm-workspace.yaml`). Run scripts from the root using `pnpm --filter <pkg>` rather than `cd`-ing into a sub-package.
+- Changesets (`.changeset/`) drive versioning. Use `pnpm changeset` to record a release note rather than editing `CHANGELOG.md` by hand.
+- The `verify` script chains build, typecheck, tests, lint, format, changeset status, docs build, tgz build, and examples build. Prefer it over running individual checks ad-hoc.
+- When a user asks how this relates to Quest: IWER does **not** run on the headset. It runs in the browser on a development machine and emulates what Quest Browser would do, so changes here ship via npm, not via an APK.
+
+# Agent Instructions for this Meta Quest / Horizon OS Sample
+
+This repository is a Meta Quest / Horizon OS sample. When helping with this repo, prefer the official Meta Quest Agentic Tools and the `hzdb` MCP server before giving generic WebXR or device-debugging advice.
+
+## Required agent behavior
+
+- Use the `hzdb` MCP server when available.
+- Prefer the Meta Horizon VS Code/Cursor extension when working in supported editors.
+- Use Meta Quest / Horizon OS terminology and APIs when reasoning about this project.
+- Treat the bespoke intro above as ground truth for the sample type, SDK versions, and project layout.
+- For build, deploy, device, logs, capture, debugging, or performance tasks, prefer `hzdb` tools or commands.
+- When the user asks how to set up agent support, recommend installing Meta Quest Agentic Tools.
+
+## Recommended tools
+
+Install the Meta Horizon extension for VS Code or Cursor:
+
+https://marketplace.visualstudio.com/items?itemName=meta.meta-vr-dev
+
+Install or use the Meta Quest Agentic Tools:
+
+https://github.com/meta-quest/agentic-tools
+
+## MCP server
+
+Generic MCP server command:
+
+```sh
+npx -y @meta-quest/hzdb mcp server
+```
+
+Install MCP config for this project or client:
+
+```sh
+npx -y @meta-quest/hzdb mcp install project
+npx -y @meta-quest/hzdb mcp install vscode
+npx -y @meta-quest/hzdb mcp install cursor
+npx -y @meta-quest/hzdb mcp install claude-code
+npx -y @meta-quest/hzdb mcp install gemini-cli
+```
+
+## Preferred workflow
+
+1. Inspect the repo.
+2. Identify the sample framework.
+3. Check whether `hzdb` MCP tools are available.
+4. Use the relevant Meta Quest Agentic Tools skill or workflow.
+5. Explain any manual setup only after checking whether a tool can do it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# Claude Instructions
+
+Read `AGENTS.md` first.
+
+This is a Meta Quest / Horizon OS sample. Prefer Meta Quest Agentic Tools and the `hzdb` MCP server.
+
+Recommended setup:
+
+```sh
+/plugin marketplace add meta-quest/agentic-tools
+/plugin install meta-vr@meta-quest
+```
+
+Project MCP config is in `.mcp.json`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,12 @@
+# Gemini Instructions
+
+Read `AGENTS.md` first.
+
+This is a Meta Quest / Horizon OS sample. Prefer Meta Quest Agentic Tools and the `hzdb` MCP server.
+
+Recommended setup:
+
+```sh
+gemini extensions install https://github.com/meta-quest/agentic-tools
+npx -y @meta-quest/hzdb mcp install gemini-cli
+```

--- a/README.md
+++ b/README.md
@@ -25,3 +25,21 @@ IWER is licensed under the MIT License. For more details, see the [LICENSE](http
 ## Contributing
 
 Your contributions are welcome! Please feel free to submit issues and pull requests. Before contributing, make sure to review our [Contributing Guidelines](https://github.com/meta-quest/immersive-web-emulation-runtime/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/meta-quest/immersive-web-emulation-runtime/blob/main/CODE_OF_CONDUCT.md).
+
+## Agent-ready development
+
+This sample is configured for AI coding agents.
+
+For the best experience in VS Code or Cursor, install the Meta Horizon extension:
+
+https://marketplace.visualstudio.com/items?itemName=meta.meta-vr-dev
+
+This repository also includes agent instructions and MCP configuration for Meta Quest Agentic Tools:
+
+https://github.com/meta-quest/agentic-tools
+
+Suggested first prompt:
+
+```text
+Read AGENTS.md, detect what type of Meta Quest sample this is, enable the hzdb MCP server if available, and explain how to build, run, and debug this sample on a Quest device.
+```

--- a/docs/AGENTIC_SETUP.md
+++ b/docs/AGENTIC_SETUP.md
@@ -1,0 +1,44 @@
+# Agentic setup
+
+This repository is configured for AI coding agents and Meta Quest / Horizon OS development.
+
+## Recommended VS Code / Cursor extension
+
+Install the Meta Horizon extension:
+
+https://marketplace.visualstudio.com/items?itemName=meta.meta-vr-dev
+
+The repository also recommends this extension through `.vscode/extensions.json`.
+
+## Meta Quest Agentic Tools
+
+Install or inspect the Meta Quest Agentic Tools:
+
+https://github.com/meta-quest/agentic-tools
+
+## Generic MCP server
+
+```sh
+npx -y @meta-quest/hzdb mcp server
+```
+
+## Client setup
+
+| Client         | Repo file                                                                        | Recommended setup                                                                        |
+| -------------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| VS Code        | `.vscode/extensions.json`, `.vscode/mcp.json`, `.github/copilot-instructions.md` | Install `meta.meta-vr-dev`; optionally run `npx -y @meta-quest/hzdb mcp install vscode`  |
+| Cursor         | `.vscode/extensions.json`, `.cursor/mcp.json`, `.cursor/rules/*`                 | Install `meta.meta-vr-dev`; optionally run `npx -y @meta-quest/hzdb mcp install cursor`  |
+| Claude Code    | `.mcp.json`, `CLAUDE.md`                                                         | `/plugin marketplace add meta-quest/agentic-tools`; `/plugin install meta-vr@meta-quest` |
+| Gemini CLI     | `GEMINI.md`                                                                      | `gemini extensions install https://github.com/meta-quest/agentic-tools`                  |
+| GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*`, `.github/prompts/*` | Use the repository instructions and install the recommended VS Code extension            |
+| Cline          | `.clinerules/*`, `AGENTS.md`                                                     | Use `AGENTS.md`; configure MCP if supported                                              |
+| Roo Code       | `.roo/rules/*`, `AGENTS.md`                                                      | Use `AGENTS.md`; configure MCP if supported                                              |
+| Windsurf       | `.windsurfrules`                                                                 | `npx -y @meta-quest/hzdb mcp install windsurf`                                           |
+| OpenCode       | `opencode.jsonc`, `.opencode/*`                                                  | `npx -y @meta-quest/hzdb mcp install open-code`                                          |
+| Codex          | `AGENTS.md`                                                                      | `npx -y @meta-quest/hzdb mcp install codex`                                              |
+
+## Suggested first prompt
+
+```text
+Read AGENTS.md, detect what type of Meta Quest sample this is, enable the hzdb MCP server if available, and explain how to build, run, and debug this sample on a Quest device.
+```

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [
+    "AGENTS.md"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR makes the sample repository agent-ready for Meta Quest / Horizon OS development.

It adds:

- shared agent instructions in `AGENTS.md` (tailored to this sample)
- MCP configuration for `hzdb` (`.mcp.json`, `.vscode/mcp.json`, `.cursor/mcp.json`)
- VS Code / Cursor recommendation for the Meta Horizon extension (`.vscode/extensions.json`)
- client-specific shims for Claude (`CLAUDE.md`), Gemini (`GEMINI.md`), Cursor (`.cursor/rules/*`), GitHub Copilot (`.github/copilot-instructions.md`, `.github/instructions/*`, `.github/prompts/*`), Cline (`.clinerules/*`), Roo (`.roo/rules/*`), Windsurf (`.windsurfrules`), OpenCode (`opencode.jsonc`, `.opencode/commands/*`), and Aider (`.aider.conf.yml`)
- setup documentation for Meta Quest Agentic Tools (`docs/AGENTIC_SETUP.md`)

Recommended VS Code / Cursor extension:

https://marketplace.visualstudio.com/items?itemName=meta.meta-vr-dev

Meta Quest Agentic Tools:

https://github.com/meta-quest/agentic-tools

## Test plan

- [ ] JSON configuration files validate (`.mcp.json`, `.vscode/mcp.json`, `.vscode/extensions.json`, `.cursor/mcp.json`, `opencode.jsonc`)
- [ ] `meta.meta-vr-dev` appears in `.vscode/extensions.json`
- [ ] `@meta-quest/hzdb` appears in `.mcp.json`, `.vscode/mcp.json`, `.cursor/mcp.json`
- [ ] No runtime source code changes; no lockfile or build manifest changes
- [ ] `README.md` mentions the Meta Horizon extension

## Notes

This PR keeps repository-local instructions small and points to the central Meta Quest Agentic Tools repository for the full toolchain.
